### PR TITLE
Avoid NameError when LOCAL=False

### DIFF
--- a/python/sprint5_final/B/code.py
+++ b/python/sprint5_final/B/code.py
@@ -1,20 +1,19 @@
-# ! change LOCAL to False before submitting !
-# set LOCAL to True for local testing
-
 from typing import Optional
 
-LOCAL = True
-if LOCAL:
-    class Node:  
-        def __init__(self, left=None, right=None, value=0):  
-            self.right = right
-            self.left = left
-            self.value = value
 
-def remove(root, key) -> Optional[Node]:
+# ! Do not change Node class !
+class Node:
+    def __init__(self, left=None, right=None, value=0):
+        self.right = right
+        self.left = left
+        self.value = value
+
+
+def remove(root, key) -> Optional["Node"]:
     #  Your code
     #  “ヽ(´▽｀)ノ”
-    pass
+    ...
+
 
 def test():
     node1 = Node(None, None, 2)
@@ -24,10 +23,11 @@ def test():
     node5 = Node(node4, None, 8)
     node6 = Node(node5, None, 10)
     node7 = Node(node3, node6, 5)
-    newHead = remove(node7, 10)
-    assert newHead.value == 5
-    assert newHead.right is node5
-    assert newHead.right.value == 8
+    new_head = remove(node7, 10)
+    assert new_head.value == 5
+    assert new_head.right is node5
+    assert new_head.right.value == 8
+
 
 if __name__ == '__main__':
     test()


### PR DESCRIPTION
Финальная задачка [Спринт 5: Удали узел](https://contest.yandex.ru/contest/24810/problems/B/) не проходит по этому шаблону через Make.

В шаблоне написано:
```
# ! change LOCAL to False before submitting !
# set LOCAL to True for local testing
```
Но по факту всё наоборот: когда `LOCAL= True`, то тесты проходят, а когда `False`, то нет.

Ошибка на той строчке, где типы:
```
    def remove(root, key) -> Optional[Node]:
NameError: name 'Node' is not defined
```
И они как раз были [добавлены недавно](https://github.com/Yandex-Practicum/algorithms-templates/commit/9f74a845522854aba53f8beaa8ad792307b24f3e). 

Видимо класс `Node` определяется уже после кода студента, поэтому он ещё не доступен на этой строчке.

Предлагаю добавить строчку `from __future__ import annotations`  или добавить кавычки к `Optional['Node']`.  Оба эти варианта работают. Я выбрал кавычки. IDE нормально работают с типизацией классами в кавычках, распознают их именно как классы.

Также думаю, что для упрощения можно вообще не делать переключатель LOCAL, так как класс Node всё равно переопределится при запуске через Make, и это работает. 

Также код приведен к PEP8: snake_case переменных и правильное количество пропущенных строк.