### PR TITLE
Remove "const" from Node* left and Node* right

### DIFF
--- a/cpp/sprint5/J/code.cpp
+++ b/cpp/sprint5/J/code.cpp
@@ -1,8 +1,8 @@
 #ifndef REMOTE_JUDGE
 struct Node {  
   int value;  
-  const Node* left = nullptr;  
-  const Node* right = nullptr;
+  Node* left = nullptr;  
+  Node* right = nullptr;
   Node(Node* left, Node* right, int value) : value(value), left(left), right(right) {}
 };  
 #endif


### PR DESCRIPTION
The "const" in the example code is very confusing, as it doesn't allow modifying child nodes in a task that requires addition of a new node in a tree. The header for the "Node" struct in the REMOTE_JUDGE doesn't have const in the pointers to child nodes, this leads to a lot of time wasted when attempting to complete this task based on the given code.