### PR TITLE
Исправил конструктор. Спринт 2 пример задачи Е. Всё наоборот.

### DIFF
--- a/kotlin/sprint2/E/Solution.kt
+++ b/kotlin/sprint2/E/Solution.kt
@@ -1,17 +1,11 @@
 /**
  * Comment it before submitting
- *
- * class Node<V> {
- *     var value: V
- *     var next: Node<V>?
- *     var prev: Node<V>?
- *
- *     constructor(value: V) {
- *         this.value = value
- *         next = null
- *         prev = null
- *     }
- * }
+ * 
+ * class Node<V>(
+ *     var value: V,
+ *     var prev: Node<V>? = null,
+ *     var next: Node<V>? = null
+ * )
  */
 
 


### PR DESCRIPTION
В тесте в конструктор передавалось 3 аргумента, но код в комментарии принимал только один аргумент, чтобы работало в соответствии с функцией `test` и в соответствии со стандартами стиля написания Kotlin