### PR TITLE
Исправление создания начального двусвязного списка для задачи Спринт2-E

### DIFF
--- a/csharp/sprint2/E/Solution.cs
+++ b/csharp/sprint2/E/Solution.cs
@@ -29,6 +29,9 @@ public class Solution
         var node2 = new Node<string>("node2", node3, null);
         var node1 = new Node<string>("node1", node2, null);
         var node0 = new Node<string>("node0", node1, null);
+        node1.Prev = node0;
+        node2.Prev = node1;
+        node3.Prev = node2;
         var newNode = Solution.Solve(node0);
         /*
         result is : newNode == node3


### PR DESCRIPTION
Спринт 2. Задача "E. Всё наоборот"

В формулировке задачи указано
```Внимание: в этой задаче не нужно считывать входные данные. Нужно написать только функцию, которая принимает на вход голову двусвязного списка и возвращает голову перевёрнутого списка.```

В исходном коде шаблона некорректно создаётся двусвязный список: не проставляется ряд обратных связей через свойство Prev. При дебаге наткнулся на ошибку, оказалось она в шаблоне.

В той же задаче для JavaScript есть выставление этих связей. 
https://github.com/Yandex-Practicum/algorithms-templates/blob/98d95f1a48a9fb5264eea43b6216904a9dfc1379/js/sprint2/E/code.js#L21